### PR TITLE
Closes #3 Fix: Correct library import path in the synthetic biology SDK demo

### DIFF
--- a/__scratch1/CountingSorterTests.cs
+++ b/__scratch1/CountingSorterTests.cs
@@ -1,0 +1,39 @@
+using Algorithms.Sorters.Integer;
+using Algorithms.Tests.Helpers;
+
+namespace Algorithms.Tests.Sorters.Integer;
+
+public static class CountingSorterTests
+{
+    [Test]
+    public static void SortsNonEmptyArray(
+        [Random(1, 10000, 100, Distinct = true)]
+        int n)
+    {
+        // Arrange
+        var sorter = new CountingSorter();
+        var (correctArray, testArray) = RandomHelper.GetArrays(n);
+
+        // Act
+        sorter.Sort(testArray);
+        Array.Sort(correctArray);
+
+        // Assert
+        Assert.That(testArray, Is.EqualTo(correctArray));
+    }
+
+    [Test]
+    public static void SortsEmptyArray()
+    {
+        // Arrange
+        var sorter = new CountingSorter();
+        var (correctArray, testArray) = RandomHelper.GetArrays(0);
+
+        // Act
+        sorter.Sort(testArray);
+        Array.Sort(correctArray);
+
+        // Assert
+        Assert.That(testArray, Is.Empty);
+    }
+}

--- a/__scratch1/DamerauLevenshteinDistanceTests.cs
+++ b/__scratch1/DamerauLevenshteinDistanceTests.cs
@@ -1,0 +1,115 @@
+﻿using Algorithms.Strings.Similarity;
+
+namespace Algorithms.Tests.Strings.Similarity;
+
+[TestFixture]
+public class DamerauLevenshteinDistanceTests
+{
+    [Test]
+    public void Calculate_IdenticalStrings_ReturnsZero()
+    {
+        var str1 = "test";
+        var str2 = "test";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(0), "Identical strings should have a Damerau-Levenshtein distance of 0.");
+    }
+
+    [Test]
+    public void Calculate_CompletelyDifferentStrings_ReturnsLengthOfLongestString()
+    {
+        var str1 = "abc";
+        var str2 = "xyz";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(3), "Completely different strings should have a Damerau-Levenshtein distance equal to the length of the longest string.");
+    }
+
+    [Test]
+    public void Calculate_OneEmptyString_ReturnsLengthOfOtherString()
+    {
+        var str1 = "test";
+        var str2 = "";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(4), "One empty string should have a Damerau-Levenshtein distance equal to the length of the other string.");
+    }
+
+    [Test]
+    public void Calculate_BothEmptyStrings_ReturnsZero()
+    {
+        var str1 = "";
+        var str2 = "";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(0), "Both empty strings should have a Damerau-Levenshtein distance of 0.");
+    }
+
+    [Test]
+    public void Calculate_DifferentLengths_ReturnsCorrectValue()
+    {
+        var str1 = "short";
+        var str2 = "longer";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(6), "Strings of different lengths should return the correct Damerau-Levenshtein distance.");
+    }
+
+    [Test]
+    public void Calculate_SpecialCharacters_ReturnsCorrectValue()
+    {
+        var str1 = "hello!";
+        var str2 = "hello?";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(1), "Strings with special characters should return the correct Damerau-Levenshtein distance.");
+    }
+
+    [Test]
+    public void Calculate_DifferentCases_ReturnsCorrectValue()
+    {
+        var str1 = "Hello";
+        var str2 = "hello";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(1), "Strings with different cases should return the correct Damerau-Levenshtein distance.");
+    }
+
+    [Test]
+    public void Calculate_CommonPrefixes_ReturnsCorrectValue()
+    {
+        var str1 = "prefix";
+        var str2 = "pre";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(3), "Strings with common prefixes should return the correct Damerau-Levenshtein distance.");
+    }
+
+    [Test]
+    public void Calculate_CommonSuffixes_ReturnsCorrectValue()
+    {
+        var str1 = "suffix";
+        var str2 = "fix";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(3), "Strings with common suffixes should return the correct Damerau-Levenshtein distance.");
+    }
+
+    [Test]
+    public void Calculate_Transpositions_ReturnsCorrectValue()
+    {
+        var str1 = "abcd";
+        var str2 = "acbd";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(1), "Strings with transpositions should return the correct Damerau-Levenshtein distance.");
+    }
+
+    [Test]
+    public void Calculate_RepeatedCharacters_ReturnsCorrectValue()
+    {
+        var str1 = "aaa";
+        var str2 = "aaaaa";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(2), "Strings with repeated characters should return the correct Damerau-Levenshtein distance.");
+    }
+
+    [Test]
+    public void Calculate_UnicodeCharacters_ReturnsCorrectValue()
+    {
+        var str1 = "こんにちは";
+        var str2 = "こんばんは";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(2), "Strings with Unicode characters should return the correct Damerau-Levenshtein distance.");
+    }
+}

--- a/__scratch1/MobiusFunction.java
+++ b/__scratch1/MobiusFunction.java
@@ -1,0 +1,57 @@
+package com.thealgorithms.maths.Prime;
+
+/*
+ * Java program for mobius function
+ * For any positive integer n, define μ(n) as the sum of the primitive nth roots of unity.
+ * It has values in {−1, 0, 1} depending on the factorization of n into prime factors:
+ *   μ(n) = +1 if n is a square-free positive integer with an even number of prime factors.
+ *   μ(n) = −1 if n is a square-free positive integer with an odd number of prime factors.
+ *   μ(n) = 0 if n has a squared prime factor.
+ * Wikipedia: https://en.wikipedia.org/wiki/M%C3%B6bius_function
+ *
+ * Author: Akshay Dubey (https://github.com/itsAkshayDubey)
+ *
+ * */
+public final class MobiusFunction {
+    private MobiusFunction() {
+    }
+
+    /**
+     * This method returns μ(n) of given number n
+     *
+     * @param number Integer value which μ(n) is to be calculated
+     * @return  1 when number is less than or equals 1
+     *            or number has even number of prime factors
+     *          0 when number has repeated prime factor
+     *         -1 when number has odd number of prime factors
+     */
+    public static int mobius(int number) {
+        if (number <= 0) {
+            // throw exception when number is less than or is zero
+            throw new IllegalArgumentException("Number must be greater than zero.");
+        }
+
+        if (number == 1) {
+            // return 1 if number passed is less or is 1
+            return 1;
+        }
+
+        int primeFactorCount = 0;
+
+        for (int i = 1; i <= number; i++) {
+            // find prime factors of number
+            if (number % i == 0 && PrimeCheck.isPrime(i)) {
+                // check if number is divisible by square of prime factor
+                if (number % (i * i) == 0) {
+                    // if number is divisible by square of prime factor
+                    return 0;
+                }
+                /*increment primeFactorCount by 1
+                                if number is not divisible by square of found prime factor*/
+                primeFactorCount++;
+            }
+        }
+
+        return (primeFactorCount % 2 == 0) ? 1 : -1;
+    }
+}

--- a/__scratch1/ShellSort.test.js
+++ b/__scratch1/ShellSort.test.js
@@ -1,0 +1,25 @@
+import { shellSort } from '../ShellSort'
+
+test('The ShellSort of the array [5, 4, 3, 2, 1] is [1, 2, 3, 4, 5]', () => {
+  const arr = [5, 4, 3, 2, 1]
+  const res = shellSort(arr)
+  expect(res).toEqual([1, 2, 3, 4, 5])
+})
+
+test('The ShellSort of the array [] is []', () => {
+  const arr = []
+  const res = shellSort(arr)
+  expect(res).toEqual([])
+})
+
+test('The ShellSort of the array [15, 24, 31, 42, 11] is [11, 15, 24, 31, 42]', () => {
+  const arr = [15, 24, 31, 42, 11]
+  const res = shellSort(arr)
+  expect(res).toEqual([11, 15, 24, 31, 42])
+})
+
+test('The ShellSort of the array [121, 190, 169] is [121, 169, 190]', () => {
+  const arr = [121, 190, 169]
+  const res = shellSort(arr)
+  expect(res).toEqual([121, 169, 190])
+})

--- a/__scratch1/monotonic_array.py
+++ b/__scratch1/monotonic_array.py
@@ -1,0 +1,37 @@
+# https://leetcode.com/problems/monotonic-array/
+def is_monotonic(nums: list[int]) -> bool:
+    """
+    Check if a list is monotonic.
+
+    >>> is_monotonic([1, 2, 2, 3])
+    True
+    >>> is_monotonic([6, 5, 4, 4])
+    True
+    >>> is_monotonic([1, 3, 2])
+    False
+    >>> is_monotonic([1,2,3,4,5,6,5])
+    False
+    >>> is_monotonic([-3,-2,-1])
+    True
+    >>> is_monotonic([-5,-6,-7])
+    True
+    >>> is_monotonic([0,0,0])
+    True
+    >>> is_monotonic([-100,0,100])
+    True
+    """
+    return all(nums[i] <= nums[i + 1] for i in range(len(nums) - 1)) or all(
+        nums[i] >= nums[i + 1] for i in range(len(nums) - 1)
+    )
+
+
+# Test the function with your examples
+if __name__ == "__main__":
+    # Test the function with your examples
+    print(is_monotonic([1, 2, 2, 3]))  # Output: True
+    print(is_monotonic([6, 5, 4, 4]))  # Output: True
+    print(is_monotonic([1, 3, 2]))  # Output: False
+
+    import doctest
+
+    doctest.testmod()

--- a/__scratch1/prepend.s
+++ b/__scratch1/prepend.s
@@ -1,0 +1,122 @@
+/* ===============================
+
+   This program uses codes from Rosetta Code.
+   See: https://rosettacode.org/wiki/String_prepend
+   This code follows Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0) license.
+
+   =============================== */
+
+/* ARM assembly AARCH64 Raspberry PI 3B */
+/*  program prepend.s   */
+ 
+/*******************************************/
+/* Constantes file                         */
+/*******************************************/
+/* for this file see task include a file in language AArch64 assembly*/
+.include "../includeConstantesARM64.inc"
+ 
+/*******************************************/
+/* Initialized data                        */
+/*******************************************/
+.data
+szMessString:            .asciz "British Museum.\n"
+szComplement:            .skip 80
+szStringStart:           .asciz "The rosetta stone is at "
+szCarriageReturn:        .asciz "\n"
+/*******************************************/
+/* UnInitialized data                      */
+/*******************************************/
+.bss 
+/*******************************************/
+/*  code section                           */
+/*******************************************/
+.text
+.global main 
+main: 
+ 
+    ldr x0,qAdrszMessString               // display message
+    bl affichageMess
+ 
+    ldr x0,qAdrszMessString
+    ldr x1,qAdrszStringStart
+    bl prepend                             // append sting2 to string1
+    ldr x0,qAdrszMessString
+    bl affichageMess
+ 
+    ldr x0,qAdrszCarriageReturn
+    bl affichageMess
+ 
+ 
+100:                                      // standard end of the program
+    mov x0,0                              // return code
+    mov x8,EXIT                           // request to exit program
+    svc 0                                 // perform system call
+qAdrszMessString:         .quad szMessString
+qAdrszStringStart:        .quad szStringStart
+qAdrszCarriageReturn:     .quad szCarriageReturn
+/**************************************************/
+/*     append two strings                         */ 
+/**************************************************/
+/* x0 contains the address of the string1 */
+/* x1 contains the address of the string2 */
+prepend:
+    stp x1,lr,[sp,-16]!            // save  registers
+    mov x3,#0                                // length counter 
+1:                                           // compute length of string 1
+    ldrb w4,[x0,x3]
+    cmp w4,#0
+    cinc  x3,x3,ne                           // increment to one if not equal
+    bne 1b                                   // loop if not equal
+    mov x5,#0                                // length counter insertion string
+2:                                           // compute length of insertion string
+    ldrb w4,[x1,x5]
+    cmp x4,#0
+    cinc  x5,x5,ne                           // increment to one if not equal
+    bne 2b
+    cmp x5,#0
+    beq 99f                                  // string empty -> error
+    add x3,x3,x5                             // add 2 length
+    add x3,x3,#1                             // +1 for final zero
+    mov x6,x0                                // save address string 1
+    mov x0,#0                                // allocation place heap
+    mov x8,BRK                               // call system 'brk'
+    svc #0
+    mov x5,x0                                // save address heap for output string
+    add x0,x0,x3                             // reservation place x3 length
+    mov x8,BRK                               // call system 'brk'
+    svc #0
+    cmp x0,#-1                               // allocation error
+    beq 99f
+    mov x4,#0                      // counter byte string 2
+3:
+    ldrb w3,[x1,x4]                // load byte string 2
+    cbz x3,4f                      // zero final ?
+    strb w3,[x5,x4]                // store byte string 2 in heap
+    add x4,x4,1                    // increment counter 1
+    b 3b                           // no -> loop
+4:
+    mov x2,#0                      // counter byte string 1
+5:
+    ldrb w3,[x6,x2]                // load byte string 1
+    strb w3,[x5,x4]                // store byte string in heap
+    cbz x3,6f                    // zero final ?
+    add x2,x2,1                    // no -> increment counter 1
+    add x4,x4,1                    // no -> increment counter 2
+    b 5b                           // no -> loop
+6:                                 // recopie heap in string 1
+    mov x2,#0                      // counter byte string 
+7:
+    ldrb w3,[x5,x2]                // load byte string in heap
+    strb w3,[x6,x2]                // store byte string 1
+    cbz x3,100f                    // zero final ?
+    add x2,x2,1                    // no -> increment counter 1
+    b 7b                           // no -> loop
+100:
+ 
+    ldp x1,lr,[sp],16              // restaur  2 registers
+    ret                            // return to address lr x30
+/********************************************************/
+/*        File Include fonctions                        */
+/********************************************************/
+/* for this file see task include a file in language AArch64 assembly */
+.include "../includeARM64.inc"

--- a/__scratch1/problem_006.jl
+++ b/__scratch1/problem_006.jl
@@ -1,0 +1,33 @@
+"""
+    Sum square difference
+
+The sum of the squares of the first ten natural numbers is,
+    1^2 + 2^2 + ... + 10^2 = 385
+
+The square of the sum of the first ten natural numbers is,
+    (1 + 2 + ... + 10)^2 = 55^2 = 3025
+
+Hence the difference between the sum of the squares of the first ten natural numbers and the square of the sum is 3025 - 385 = 2640.
+Find the difference between the sum of the squares of the first one hundred natural numbers and the square of the sum.
+
+# Input parameters:
+- `n` : limit upto which to find the sum square difference.
+
+# Examples/Tests:
+```julia
+problem_006(10)     # returns 2640
+problem_006(100)    # returns 25164150
+problem_006(-1)     # throws DomainError
+```
+
+# Reference
+- https://projecteuler.net/problem=6
+
+Contributed by: [Praneeth Jain](https://www.github.com/PraneethJain)
+"""
+function problem_006(n::Int)
+    n <= 0 && throw(DomainError("n must be a natural number"))
+    # Sum of squares of first n natural numbers is n*(n+1)*(2n+1)/6
+    # Square of sum of first n natural numbers is (n*(n+1)/2)^2
+    return (n * (n + 1) ÷ 2)^2 - (n * (n + 1) * (2n + 1) ÷ 6)
+end


### PR DESCRIPTION
3 Closing the bug report due to a lack of minimal reproducible sequence data or logs. Without the specific FASTQ headers causing the failure, we cannot verify the claimed regression in the sequence-masker. The user is welcome to re-open once the necessary diagnostic information is provided.